### PR TITLE
Freeze the Ads SDK (Android) on 16.0.0

### DIFF
--- a/admob/config.py
+++ b/admob/config.py
@@ -3,7 +3,7 @@ def can_build(plat):
 
 def configure(env):
 	if (env['platform'] == 'android'):
-		env.android_add_dependency("compile 'com.google.android.gms:play-services-ads:+'")
+		env.android_add_dependency("compile 'com.google.android.gms:play-services-ads:16.0.0'")
 		env.android_add_java_dir("android")
 		env.android_add_to_manifest("android/AndroidManifestChunk.xml")
 		env.disable_module()


### PR DESCRIPTION
Due to the requirement of app id from version 17.0.0, we freeze the module requirement on 16.0.0 for now.