### PR TITLE
 Support for setting content rating in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ The following methods are available:
 # @param int instance_id The instance id from Godot (get_instance_ID())
 init(isReal, instance_id)
 
+# Init AdMob with additional Content Rating parameters (Android Only)
+# @param bool isReal Show real ad or test ad
+# @param int instance_id The instance id from Godot (get_instance_ID())
+# @param boolean isForChildDirectedTreatment If isForChildDirectedTreatment is true, maxAdContetRating will be ignored (your maxAdContentRating would can not be other than "G")
+# @param String maxAdContentRating It's value must be "G", "PG", "T" or "MA". If the rating of your app in Play Console and your config of maxAdContentRating in AdMob are not matched, your app can be banned by Google.
+initWithContentRating(isReal, instance_id, isForChildDirectedTreatment, maxAdContentRating)
+
+
 # Banner Methods
 # --------------
 

--- a/admob/android/GodotAdMob.java
+++ b/admob/android/GodotAdMob.java
@@ -50,8 +50,20 @@ public class GodotAdMob extends Godot.SingletonBase
 	/**
 	 * Prepare for work with AdMob
 	 * @param boolean isReal Tell if the enviroment is for real or test
+	 * @param int gdscript instance id
 	 */
-	public void init(boolean isReal, int instance_id, boolean isForChildDirectedTreatment, String maxAdContentRating)
+	public void init(boolean isReal, int instance_id) {
+		this.initWithContentRating(isReal, instance_id, false, "");
+	}
+
+	/**
+	 * Init with content rating additional options 
+	 * @param boolean isReal Tell if the enviroment is for real or test
+	 * @param int gdscript instance id
+	 * @param boolean isForChildDirectedTreatment
+	 * @param String maxAdContentRating must be "G", "PG", "T" or "MA"
+	 */
+	public void initWithContentRating(boolean isReal, int instance_id, boolean isForChildDirectedTreatment, String maxAdContentRating)
 	{
 		this.isReal = isReal;
 		this.instance_id = instance_id;
@@ -62,7 +74,7 @@ public class GodotAdMob extends Godot.SingletonBase
 			extras = new Bundle();
 			extras.putString("max_ad_content_rating", maxAdContentRating);
 		}
-		Log.d("godot", "AdMob: init");
+		Log.d("godot", "AdMob: init with content rating options");
 	}
 
 
@@ -499,6 +511,7 @@ public class GodotAdMob extends Godot.SingletonBase
 	public GodotAdMob(Activity p_activity) {
 		registerClass("AdMob", new String[] {
 			"init",
+			"initWithContentRating",
 			// banner
 			"loadBanner", "showBanner", "hideBanner", "getBannerWidth", "getBannerHeight", "resize",
 			// Interstitial


### PR DESCRIPTION
The changes include the following:

* Two parameters were added to init (isForChildDirectedTreatment, maxAdContentRating)
* If isForChildDirectedTreatment is true, maxAdContetRating will be ignored (your maxAdContentRating would can not be other than "G")
* maxAdContentRating is of String type. It's value must be "G", "PG", "T" or "MA". If the rating of your app in Play Console and your config of maxAdContentRating in AdMob are not matched, your app can be banned by Google.
* "getAdRequest" method was created. This encapsules the repetitive lines of code of creating an AdRequest.