### PR TITLE
Fix for iOS Adomb crash -Multiple locks on web thread not allowed #53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.import
 .import
 *.o
+*.framework

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.import
 .import
 *.o
+*.d
 *.framework

--- a/admob/config.py
+++ b/admob/config.py
@@ -9,6 +9,6 @@ def configure(env):
 		env.disable_module()
             
 	if env['platform'] == "iphone":
-		env.Append(FRAMEWORKPATH=['modules/admob/ios/lib'])
+		env.Append(FRAMEWORKPATH=['#modules/admob/ios/lib'])
 		env.Append(CPPPATH=['#core'])
 		env.Append(LINKFLAGS=['-ObjC', '-framework','AdSupport', '-framework','CoreTelephony', '-framework','EventKit', '-framework','EventKitUI', '-framework','MessageUI', '-framework','StoreKit', '-framework','SafariServices', '-framework','CoreBluetooth', '-framework','AssetsLibrary', '-framework','CoreData', '-framework','CoreLocation', '-framework','CoreText', '-framework','ImageIO', '-framework', 'GLKit', '-framework','CoreVideo', '-framework', 'CFNetwork', '-framework', 'MobileCoreServices', '-framework', 'GoogleMobileAds'])

--- a/admob/ios/src/AdmobBanner.h
+++ b/admob/ios/src/AdmobBanner.h
@@ -7,6 +7,7 @@
     bool isReal;
     bool isOnTop;
     int instanceId;
+    NSString *adUnitId;
     ViewController *rootController;
 }
 
@@ -14,6 +15,8 @@
 - (void)loadBanner:(NSString*)bannerId :(BOOL)is_on_top;
 - (void)showBanner;
 - (void)hideBanner;
+- (void)disableBanner;
+- (void)enableBanner;
 - (void)resize;
 - (int)getBannerWidth;
 - (int)getBannerHeight;

--- a/admob/ios/src/AdmobBanner.mm
+++ b/admob/ios/src/AdmobBanner.mm
@@ -16,6 +16,7 @@
     rootController = [AppDelegate getViewController];
 }
 
+
 - (void) loadBanner:(NSString*)bannerId: (BOOL)is_on_top {
     NSLog(@"Calling loadBanner");
     
@@ -140,6 +141,29 @@
         return;
     }
     [bannerView setHidden:YES];
+}
+- (void) disableBanner {
+    NSLog(@"Calling disableBanner");
+    if (bannerView == nil || !initialized) {
+        return;
+    }
+ 
+    [bannerView setHidden:YES];
+    [bannerView removeFromSuperview];
+    adUnitId = bannerView.adUnitID;
+    bannerView = nil;
+}
+ 
+- (void) enableBanner {
+    NSLog(@"Calling enableBanner");
+    if (!initialized) {
+        return;
+    }
+ 
+    if (bannerView == nil) {
+        [self loadBanner:adUnitId:isOnTop];
+    }
+    [bannerView setHidden:NO];
 }
 
 - (void) resize {

--- a/admob/ios/src/AdmobInterstitial.h
+++ b/admob/ios/src/AdmobInterstitial.h
@@ -1,7 +1,9 @@
 #import <GoogleMobileAds/GADInterstitial.h>
 #import "app_delegate.h"
+#import "AdmobBanner.h"
 
 @interface AdmobInterstitial: NSObject <GADInterstitialDelegate> {
+    AdmobBanner *admobBanner;
     GADInterstitial *interstitial;
     bool initialized;
     bool isReal;
@@ -9,7 +11,7 @@
     ViewController *rootController;
 }
 
-- (void)initialize:(BOOL)is_real: (int)instance_id;
+- (void)initialize:(BOOL)is_real: (int)instance_id: (AdmobBanner *)banner;
 - (void)loadInterstitial:(NSString*)interstitialId;
 - (void)showInterstitial;
 

--- a/admob/ios/src/AdmobInterstitial.mm
+++ b/admob/ios/src/AdmobInterstitial.mm
@@ -10,10 +10,11 @@
     [super dealloc];
 }
 
-- (void)initialize:(BOOL)is_real: (int)instance_id {
+- (void)initialize:(BOOL)is_real: (int)instance_id: (AdmobBanner *)admob_banner {
     isReal = is_real;
     initialized = true;
     instanceId = instance_id;
+    admobBanner = admob_banner;
     rootController = [AppDelegate getViewController];
 }
 
@@ -51,6 +52,7 @@
     }
     
     if (interstitial.isReady) {
+        [admobBanner disableBanner];
         [interstitial presentFromRootViewController:rootController];
     } else {
         NSLog(@"Interstitial Ad wasn't ready");
@@ -84,6 +86,11 @@ didFailToReceiveAdWithError:(GADRequestError *)error {
 /// Tells the delegate the interstitial is to be animated off the screen.
 - (void)interstitialWillDismissScreen:(GADInterstitial *)ad {
     NSLog(@"interstitialWillDismissScreen");
+    [self performSelector:@selector(bannerEnable) withObject:nil afterDelay:0];
+}
+- (void)bannerEnable{
+    NSLog(@"banner enable call");
+    [admobBanner enableBanner];
 }
 
 /// Tells the delegate the interstitial had been animated off the screen.
@@ -91,6 +98,7 @@ didFailToReceiveAdWithError:(GADRequestError *)error {
     NSLog(@"interstitialDidDismissScreen");
     Object *obj = ObjectDB::get_instance(instanceId);
     obj->call_deferred("_on_interstitial_close");
+ 
 }
 
 /// Tells the delegate that a user click will open another app

--- a/admob/ios/src/AdmobRewarded.h
+++ b/admob/ios/src/AdmobRewarded.h
@@ -1,15 +1,16 @@
 #import "app_delegate.h"
 #import <GoogleMobileAds/GADRewardBasedVideoAdDelegate.h>
-
+#import "AdmobBanner.h"
 
 @interface AdmobRewarded: NSObject <GADRewardBasedVideoAdDelegate> {
+    AdmobBanner *admobBanner;
     bool initialized;
     bool isReal;
     int instanceId;
     ViewController *rootController;
 }
 
-- (void)initialize:(BOOL)is_real: (int)instance_id;
+- (void)initialize:(BOOL)is_real: (int)instance_id: (AdmobBanner *)banner;
 - (void)loadRewardedVideo:(NSString*)rewardedId;
 - (void)showRewardedVideo;
 

--- a/admob/ios/src/AdmobRewarded.mm
+++ b/admob/ios/src/AdmobRewarded.mm
@@ -7,10 +7,11 @@
 @implementation AdmobRewarded
 
 
-- (void)initialize:(BOOL)is_real: (int)instance_id {
+- (void)initialize:(BOOL)is_real: (int)instance_id: (AdmobBanner *)admob_banner {
     isReal = is_real;
     initialized = true;
     instanceId = instance_id;
+    admobBanner = admob_banner;
     rootController = [AppDelegate getViewController];
 }
 
@@ -42,6 +43,7 @@
     }
     
     if ([[GADRewardBasedVideoAd sharedInstance] isReady]) {
+        [admobBanner disableBanner];
         [[GADRewardBasedVideoAd sharedInstance] presentFromRootViewController:rootController];
     }
     
@@ -78,8 +80,13 @@
          
 - (void)rewardBasedVideoAdDidClose:(GADRewardBasedVideoAd *)rewardBasedVideoAd {
     NSLog(@"Reward based video ad is closed.");
+    [self performSelector:@selector(bannerEnable) withObject:nil afterDelay:0];
     Object *obj = ObjectDB::get_instance(instanceId);
     obj->call_deferred("_on_rewarded_video_ad_closed");
+}
+- (void)bannerEnable{
+    NSLog(@"banner enable call");
+    [admobBanner enableBanner];
 }
          
 - (void)rewardBasedVideoAdWillLeaveApplication:(GADRewardBasedVideoAd *)rewardBasedVideoAd {

--- a/admob/ios/src/godotAdmob.mm
+++ b/admob/ios/src/godotAdmob.mm
@@ -33,7 +33,7 @@ void GodotAdmob::init(bool isReal, int instanceId) {
     [interstitial initialize:isReal :instanceId :banner];
     
     rewarded = [AdmobRewarded alloc];
-    [rewarded initialize:isReal :instanceId];
+    [rewarded initialize:isReal :instanceId :banner];
 }
 
 

--- a/admob/ios/src/godotAdmob.mm
+++ b/admob/ios/src/godotAdmob.mm
@@ -30,7 +30,7 @@ void GodotAdmob::init(bool isReal, int instanceId) {
     [banner initialize :isReal :instanceId];
     
     interstitial = [AdmobInterstitial alloc];
-    [interstitial initialize:isReal :instanceId];
+    [interstitial initialize:isReal :instanceId :banner];
     
     rewarded = [AdmobRewarded alloc];
     [rewarded initialize:isReal :instanceId];


### PR DESCRIPTION
I added disableBanner and enableBanner functions which removes and reinitializes the banner ad.
And Interstitial ad and reward ad call disableBanner when it shows up and enableBanner when il closes.
I tested with the latest Admob framework(7.48) on Emulator and Device (iOS 12)
There is no crash with the actual example godot script (Godot3)
