### PR TITLE
banner enable delay added

### DIFF
--- a/admob/ios/src/AdmobBanner.h
+++ b/admob/ios/src/AdmobBanner.h
@@ -1,6 +1,8 @@
 #import <GoogleMobileAds/GADBannerView.h>
 #import "app_delegate.h"
 
+#define BANNER_ENABLE_DELAY 5
+ 
 @interface AdmobBanner: NSObject <GADBannerViewDelegate> {
     GADBannerView *bannerView;
     bool initialized;

--- a/admob/ios/src/AdmobInterstitial.mm
+++ b/admob/ios/src/AdmobInterstitial.mm
@@ -86,7 +86,7 @@ didFailToReceiveAdWithError:(GADRequestError *)error {
 /// Tells the delegate the interstitial is to be animated off the screen.
 - (void)interstitialWillDismissScreen:(GADInterstitial *)ad {
     NSLog(@"interstitialWillDismissScreen");
-    [self performSelector:@selector(bannerEnable) withObject:nil afterDelay:0];
+    [self performSelector:@selector(bannerEnable) withObject:nil afterDelay:BANNER_ENABLE_DELAY];
 }
 - (void)bannerEnable{
     NSLog(@"banner enable call");

--- a/admob/ios/src/AdmobRewarded.mm
+++ b/admob/ios/src/AdmobRewarded.mm
@@ -80,7 +80,8 @@
          
 - (void)rewardBasedVideoAdDidClose:(GADRewardBasedVideoAd *)rewardBasedVideoAd {
     NSLog(@"Reward based video ad is closed.");
-    [self performSelector:@selector(bannerEnable) withObject:nil afterDelay:0];
+    NSLog(@"Enable Banner with delay:%d",BANNER_ENABLE_DELAY);
+    [self performSelector:@selector(bannerEnable) withObject:nil afterDelay:BANNER_ENABLE_DELAY];
     Object *obj = ObjectDB::get_instance(instanceId);
     obj->call_deferred("_on_rewarded_video_ad_closed");
 }


### PR DESCRIPTION
I added BANNER_ENABLE_DELAY to change the delay for the banner ad enabling after interstitial or  RewardBasedVideoAd because of the bug report here:
https://github.com/kloder-games/godot-admob/issues/53#issuecomment-521270007.

I tested the RewardBasedVideo with 2 seconds of delay and on the device(iPhoneXR) it crashed once from time to time ,so I set 5 seconds as default value but one can easily change.


