### PR TITLE
fix adView leaks when calling loadBanner multiple times

### DIFF
--- a/admob/android/GodotAdMob.java
+++ b/admob/android/GodotAdMob.java
@@ -226,6 +226,11 @@ public class GodotAdMob extends Godot.SingletonBase
 				);
 				if(isOnTop) adParams.gravity = Gravity.TOP;
 				else adParams.gravity = Gravity.BOTTOM;
+				
+				if (adView != null)
+				{
+					layout.removeView(adView); // Remove the old view
+				}
 
 				adView = new AdView(activity);
 				adView.setAdUnitId(id);


### PR DESCRIPTION
adView may leak when calling loadBanner more than 1 time that causes hideBanner cannot work properly