### PR TITLE
[ERROR] The number os arguments in initWithContentRating is different on https://github.com/Shin-NiL/Godot-Android-Admob-Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ The following methods are available:
 # @param int instance_id The instance id from Godot (get_instance_ID())
 init(isReal, instance_id)
 
-# Init AdMob with additional Content Rating parameters (Android Only)
+# Init AdMob with additional Content Rating parameters (Android and iOS)
 # @param bool isReal Show real ad or test ad
 # @param int instance_id The instance id from Godot (get_instance_ID())
 # @param boolean isForChildDirectedTreatment If isForChildDirectedTreatment is true, maxAdContetRating will be ignored (your maxAdContentRating would can not be other than "G")
+# @param boolean isPersonalized Ads are personalized by default, GDPR compliance within the European Economic Area may require you to disable personalization."
 # @param String maxAdContentRating It's value must be "G", "PG", "T" or "MA". If the rating of your app in Play Console and your config of maxAdContentRating in AdMob are not matched, your app can be banned by Google.
-initWithContentRating(isReal, instance_id, isForChildDirectedTreatment, maxAdContentRating)
+initWithContentRating(isReal, instance_id, isForChildDirectedTreatment, isPersonalized, maxAdContentRating)
 
 
 # Banner Methods

--- a/admob/android/GodotAdMob.java
+++ b/admob/android/GodotAdMob.java
@@ -35,6 +35,7 @@ public class GodotAdMob extends Godot.SingletonBase
 
 	private boolean isReal = false; // Store if is real or not
 	private boolean isForChildDirectedTreatment = false; // Store if is children directed treatment desired
+	private boolean isPersonalized = true; // ads are personalized by default, GDPR compliance within the European Economic Area may require you to disable personalization.
 	private String maxAdContentRating = ""; // Store maxAdContentRating ("G", "PG", "T" or "MA")
 	private Bundle extras = null;
 
@@ -53,29 +54,42 @@ public class GodotAdMob extends Godot.SingletonBase
 	 * @param int gdscript instance id
 	 */
 	public void init(boolean isReal, int instance_id) {
-		this.initWithContentRating(isReal, instance_id, false, "");
+		this.initWithContentRating(isReal, instance_id, false, true, "");
 	}
-
 	/**
 	 * Init with content rating additional options 
 	 * @param boolean isReal Tell if the enviroment is for real or test
 	 * @param int gdscript instance id
-	 * @param boolean isForChildDirectedTreatment
+	 * @param boolean isPersonalized If ads should be personalized or not.
+	 *  GDPR compliance within the European Economic Area requires that you
+	 *  disable ad personalization if the user does not wish to opt into
+	 *  ad personalization.
 	 * @param String maxAdContentRating must be "G", "PG", "T" or "MA"
 	 */
-	public void initWithContentRating(boolean isReal, int instance_id, boolean isForChildDirectedTreatment, String maxAdContentRating)
+	public void initWithContentRating(boolean isReal, int instance_id, boolean isForChildDirectedTreatment, boolean isPersonalized, String maxAdContentRating)
 	{
 		this.isReal = isReal;
 		this.instance_id = instance_id;
 		this.isForChildDirectedTreatment = isForChildDirectedTreatment;
+		this.isPersonalized = isPersonalized;
 		this.maxAdContentRating = maxAdContentRating;
 		if (maxAdContentRating != null && maxAdContentRating != "")
 		{
 			extras = new Bundle();
 			extras.putString("max_ad_content_rating", maxAdContentRating);
 		}
+		if(!isPersonalized)
+		{
+			// https://developers.google.com/admob/android/eu-consent#forward_consent_to_the_google_mobile_ads_sdk
+			if(extras == null)
+			{
+				extras = new Bundle();
+			}
+			extras.putString("npa", "1");
+		}
 		Log.d("godot", "AdMob: init with content rating options");
 	}
+
 
 
 	/**


### PR DESCRIPTION
The issue is: https://github.com/kloder-games/godot-admob/issues/130.

Adding this feature will make iOS version and Android version on the Godot's old versions.

debug file is attached (version tested: v3.1.2)
[android_debug.zip](https://github.com/kloder-games/godot-admob/files/4549380/android_debug.zip)

